### PR TITLE
모바일 (특히 iOS 에서) 달력 smooth scroll 적용되지 않던 문제 수정 외

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react": "18.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "18.2.0",
-    "react-progressbar.js": "^0.2.0"
+    "react-progressbar.js": "^0.2.0",
+    "seamless-scroll-polyfill": "^2.2.0"
   },
   "devDependencies": {
     "@types/node": "18.7.14",

--- a/src/components/pages/main/Calendar/index.tsx
+++ b/src/components/pages/main/Calendar/index.tsx
@@ -9,6 +9,7 @@ import {
 import { addDays, addMonths, subDays, subMonths } from "date-fns";
 import getDaysInMonth from "date-fns/getDaysInMonth";
 import lastDayOfMonth from "date-fns/lastDayOfMonth";
+import { scrollIntoView } from "seamless-scroll-polyfill";
 
 import arrowLeftIcon from "/public/icons/arrow_left.svg";
 import arrowRightIcon from "/public/icons/arrow_right.svg";
@@ -55,12 +56,15 @@ function Calendar({ selectedDate, onDateChange, ...props }: Props) {
   const currentDateCardRef = useRef<HTMLDivElement>();
   const DummyRef = useRef<HTMLDivElement>();
 
-  const executeScroll = () =>
-    currentDateCardRef.current?.scrollIntoView({
-      behavior: "smooth",
-      block: "nearest",
-      inline: "center",
-    });
+  const executeScroll = () => {
+    if (currentDateCardRef.current) {
+      scrollIntoView(currentDateCardRef.current, {
+        behavior: "smooth",
+        block: "nearest",
+        inline: "center",
+      });
+    }
+  };
 
   useEffect(() => {
     setTimeout(() => {

--- a/src/components/pages/main/Calendar/index.tsx
+++ b/src/components/pages/main/Calendar/index.tsx
@@ -54,21 +54,27 @@ function Calendar({ selectedDate, onDateChange, ...props }: Props) {
   const populatedDateArray = populateDateArray(firstDayInThisMohth, lastDayInThisMonth);
 
   const currentDateCardRef = useRef<HTMLDivElement>();
+  // 월 전환 시 첫번째 날짜로 스크롤 시키기 위한 ref
+  const firstDateCardRef = useRef<HTMLDivElement>();
   const DummyRef = useRef<HTMLDivElement>();
 
-  const executeScroll = () => {
-    if (currentDateCardRef.current) {
-      scrollIntoView(currentDateCardRef.current, {
+  // 부득이 Generic 에 대한 추론 문제로 인해 any 사용..
+  // TODO: any 를 걷어내자...
+  function executeScroll(ref: any) {
+    if (ref.current) {
+      scrollIntoView(ref.current, {
         behavior: "smooth",
         block: "nearest",
         inline: "center",
       });
     }
-  };
+  }
 
   useEffect(() => {
     setTimeout(() => {
-      executeScroll();
+      if (currentDateCardRef.current) {
+        executeScroll(currentDateCardRef);
+      }
     }, 100);
   }, []);
 
@@ -80,7 +86,10 @@ function Calendar({ selectedDate, onDateChange, ...props }: Props) {
           src={arrowLeftIcon.src}
           width={30}
           height={30}
-          onClick={() => setCurrentDay(subMonths(currentDay, 1))}
+          onClick={() => {
+            setCurrentDay(subMonths(currentDay, 1));
+            executeScroll(firstDateCardRef);
+          }}
         />
         <CalendarMonthSelectorMonthText>
           {currentDay.getFullYear()}년 {currentDay.getMonth() + 1}월
@@ -90,17 +99,22 @@ function Calendar({ selectedDate, onDateChange, ...props }: Props) {
           src={arrowRightIcon.src}
           width={30}
           height={30}
-          onClick={() => setCurrentDay(addMonths(currentDay, 1))}
+          onClick={() => {
+            setCurrentDay(addMonths(currentDay, 1));
+            executeScroll(firstDateCardRef);
+          }}
         />
       </CalendarMonthSelectorContainer>
       <StyledCalendar>
         {populatedDateArray.map((date, index) => {
           const isToday = compareUTCYYYYDDMM(today, date);
+          const isFirstDay = compareUTCYYYYDDMM(firstDayInThisMohth, date);
+
           const isSelected = compareUTCYYYYDDMM(selectedDate, date);
 
           return (
             <DateCard
-              ref={isToday ? (currentDateCardRef as any) : DummyRef}
+              ref={isToday ? (currentDateCardRef as any) : isFirstDay ? firstDateCardRef : DummyRef}
               dateCardTitle={String(date.getUTCDate())}
               dateCardContent={DAY_LOOKUP_ARRAY[date.getUTCDay()]}
               isToday={isToday}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,11 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
+seamless-scroll-polyfill@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/seamless-scroll-polyfill/-/seamless-scroll-polyfill-2.2.0.tgz#422f4a7d1b3a7d0ea86f8afad3d6abea2c66a000"
+  integrity sha512-c4KHfltYY8oFRt987Kl9i4xRLylIpg1YHWsOyH1kj4SP+W+8PtOiKrLyv8L6xbHvwQpofOZ98AWpGPEJK++udQ==
+
 semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"


### PR DESCRIPTION
- iOS 모바일 브라우저 대응을 위해 `seamless-scroll-polyfill` 라이브러리를 추가하여 도입합니다
- 달력 월 전환 시 항상 그 달의 맨 첫번째 날로 스크롤되도록 합니다. 